### PR TITLE
Ornate spyglass

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -1150,6 +1150,16 @@ Map::PlayerRelocation(Player *player, float x, float y, float z, float orientati
 
     player->OnRelocated();
 
+
+    // Ornate Spyglass case, the player's camera is at range in front of him
+    // When the player turns, keep it in front of the player
+    if (!player->m_movementInfo.HasMovementFlag(MOVEFLAG_MASK_MOVING_OR_TURN))
+        if (player->GetLongSight())
+        {
+            player->UpdateLongSight();
+            player->GetCamera().UpdateVisibilityForOwner();
+        }
+
     NGridType* newGrid = getNGrid(new_cell.GridX(), new_cell.GridY());
     if (!same_cell && newGrid->GetGridState() != GRID_STATE_ACTIVE)
     {

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -591,6 +591,9 @@ Player::Player(WorldSession *session) : Unit(),
     xy_speed = 0.0f;
 
     m_justBoarded = false;
+
+    m_longSightSpell = 0;
+    m_longSightRange = 0.0f;
 }
 
 Player::~Player()
@@ -17982,6 +17985,51 @@ template void Player::UpdateVisibilityOf(WorldObject const* viewPoint, Corpse*  
 template void Player::UpdateVisibilityOf(WorldObject const* viewPoint, GameObject*    target, UpdateData& data, std::set<WorldObject*>& visibleNow);
 template void Player::UpdateVisibilityOf(WorldObject const* viewPoint, DynamicObject* target, UpdateData& data, std::set<WorldObject*>& visibleNow);
 template void Player::UpdateVisibilityOf(WorldObject const* viewPoint, WorldObject*   target, UpdateData& data, std::set<WorldObject*>& visibleNow);
+
+void Player::SetLongSight(const Aura* aura)
+{
+    if (aura)
+    {
+        // already an active long sight spell
+        if (m_longSightSpell)
+            return;
+        m_longSightSpell = aura->GetSpellProto()->Id;
+        // Should the viewpoint be placed at a fixed range or at visibility distance ?
+        // In absence of evidence, let's move the camera at visibility distance in front of the player
+        m_longSightRange = GetMap()->GetVisibilityDistance();
+        DynamicObject* dynObj = new DynamicObject;
+        if (!dynObj->Create(GetMap()->GenerateLocalLowGuid(HIGHGUID_DYNAMICOBJECT), this, m_longSightSpell,
+            aura->GetEffIndex(), GetPositionX(), GetPositionY(), GetPositionZ(), 0, 0, DYNAMIC_OBJECT_FARSIGHT_FOCUS))
+        {
+            m_longSightSpell = 0;
+            m_longSightRange = 0.0f;
+            delete dynObj;
+            return;
+        }
+        AddDynObject(dynObj);
+        // Needed so the dyn object is properly removed
+        SetChannelObjectGuid(dynObj->GetObjectGuid());
+        GetMap()->Add(dynObj);
+        UpdateLongSight();
+        GetCamera().SetView(dynObj, false);
+    }
+    else
+    {
+        m_longSightSpell = 0;
+        m_longSightRange = 0.0f;
+        GetCamera().ResetView(false);
+    }
+}
+
+void Player::UpdateLongSight()
+{
+    if (!m_longSightSpell)
+        return;
+    if (DynamicObject* dynObj = GetDynObject(m_longSightSpell))
+        dynObj->Relocate(GetPositionX() + m_longSightRange * cos(GetOrientation()),
+                         GetPositionY() + m_longSightRange * sin(GetOrientation()),
+                         GetPositionZ());
+}
 
 void Player::InitPrimaryProfessions()
 {

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -2030,6 +2030,10 @@ class MANGOS_DLL_SPEC Player final: public Unit
 
         Camera& GetCamera() { return m_camera; }
 
+        uint32 GetLongSight() const { return m_longSightSpell; }
+        void SetLongSight(const Aura* aura = nullptr);
+        void UpdateLongSight();
+
         bool HasAtLoginFlag(AtLoginFlags f) const { return m_atLoginFlags & f; }
         void SetAtLoginFlag(AtLoginFlags f) { m_atLoginFlags |= f; }
         void RemoveAtLoginFlag(AtLoginFlags f, bool in_db_also = false);
@@ -2418,6 +2422,9 @@ class MANGOS_DLL_SPEC Player final: public Unit
 
         Unit *m_mover;
         Camera m_camera;
+
+        float m_longSightRange;
+        uint32 m_longSightSpell;
 
         GridReference<Player> m_gridRef;
         MapReference m_mapRef;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2776,11 +2776,10 @@ void Aura::HandleFarSight(bool apply, bool /*Real*/)
     if (!caster || caster->GetTypeId() != TYPEID_PLAYER)
         return;
 
-    Camera& camera = ((Player*)caster)->GetCamera();
     if (apply)
-        camera.SetView(GetTarget());
+        caster->ToPlayer()->SetLongSight(this);
     else
-        camera.ResetView();
+        caster->ToPlayer()->SetLongSight();
 }
 
 void Aura::HandleAuraTrackCreatures(bool apply, bool /*Real*/)


### PR DESCRIPTION
I put the camera at visibility range so that's a maximum of 2* visibility range increase which is still less than any other far sight class spell.
As it is working we have to rotate the character to change the view : hold right click works, hold left click won't do. I'm not sure if it's possible to lock the client view angle to the character orientation?

http://web.archive.org/web/20060908170059/http://www.thottbot.com:80/?i=5420
https://wow.gamepedia.com/index.php?title=Ornate_Spyglass&oldid=89788
https://www.youtube.com/watch?v=0bfMJCOf-yI
https://www.youtube.com/watch?v=daatrrPr9qE