### PR TITLE
Implemented Dark Iron Ale and the Morja event

### DIFF
--- a/sql/migrations/20180224160415_world.sql
+++ b/sql/migrations/20180224160415_world.sql
@@ -39,7 +39,7 @@ REPLACE INTO `spell_script_target` (`entry`, `type`, `targetEntry`) VALUES (2384
 UPDATE `quest_template` SET `RewSpellCast`=23852 WHERE `entry`=7946;
 
 REPLACE INTO `creature_ai_scripts` VALUES 
-(955405, 14871, 0, 8, 0, 100, 1, 14813, -1, 120000, 120000, 50, 10002, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Start event on Dark Iron Ale hit');
+(1487101, 14871, 0, 8, 0, 100, 1, 14813, -1, 120000, 120000, 50, 10002, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Start event on Dark Iron Ale hit');
 
 DELETE FROM `event_scripts` WHERE `id`=10002;
 INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `buddy_id`, `buddy_radius`, `buddy_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES 
@@ -53,7 +53,7 @@ REPLACE INTO `creature` VALUES (54427, 14867, 0, 0, 0, -9549.04, 38.9258, 59.255
 REPLACE INTO `game_event_creature` (`guid`, `event`) VALUES (54427, 4);
 
 REPLACE INTO `creature_ai_scripts` VALUES 
-(955406, 14867, 0, 29, 0, 100, 1, 8, 1, 120000, 120000, 50, 10003, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Start event when reaching Dark Iron ale');
+(1486701, 14867, 0, 29, 0, 100, 1, 8, 1, 120000, 120000, 50, 10003, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Start event when reaching Dark Iron ale');
 
 DELETE FROM `event_scripts` WHERE `id`=10003;
 INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `buddy_id`, `buddy_radius`, `buddy_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES 

--- a/sql/migrations/20180224160415_world.sql
+++ b/sql/migrations/20180224160415_world.sql
@@ -10,16 +10,19 @@ INSERT INTO `migrations` VALUES ('20180224160415');
 
 
 REPLACE INTO `spell_effect_mod` VALUES (14814, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 8, -1, -1, -1, -1, -1, -1, 'Throw Dark Iron Ale targetting');
-REPLACE INTO `spell_effect_mod` VALUES (14823, 2, 3, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, 'Dark Iron Ale dummy effect');
 REPLACE INTO `spell_mod` VALUES (14823, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, -1, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, 'BRD Drinking: Not Passive');
 REPLACE INTO `spell_script_target` (`entry`, `type`, `targetEntry`) VALUES (14813, 1, 9547),(14813, 1, 9554),(14813, 1, 9545),(14813, 1, 15429),(14813, 1, 14867),(14813, 1, 14871),(14813, 1, 14878);
-UPDATE `gameobject_template` SET `displayId`=3151, `data2`=20, `data4`=0, `data5`=70000 WHERE `entry`=165578;
+UPDATE `gameobject_template` SET `displayId`=3151, `data2`=20, `data4`=0, `data5`=10000 WHERE `entry`=165578;
+UPDATE `creature_template` SET `ScriptName`='npc_oozeling_jubjub' WHERE entry in (14867,15429,14878);
 
+
+-- Bar Patrons
 DELETE FROM `event_scripts` WHERE `id`=10001;
 INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `buddy_id`, `buddy_radius`, `buddy_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES 
 (10001, 0, 1, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'BRD Bar Patron - Drink Emote'),
 (10001, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 10167, 0, 0, 0, 0, 0, 0, 0, 'BRD Bar Patron - Text Emote'),
-(10001, 3, 15, 14823, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'BRD Bar Patron - Cast Drinking');
+(10001, 3, 15, 14823, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'BRD Bar Patron - Cast Drinking'),
+(10001, 3, 41, 0, 0, 0, 0, 165578, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'BRD Bar Patron - Remove Mug');
 
 REPLACE INTO `creature_ai_scripts` VALUES 
 (954703, 9547, 0, 29, 0, 100, 1, 8, 1, 0, 0, 50, 10001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Guzzling Patron - Drink Dark Iron Ale'),
@@ -27,17 +30,40 @@ REPLACE INTO `creature_ai_scripts` VALUES
 (955404, 9554, 0, 29, 0, 100, 1, 8, 1, 0, 0, 50, 10001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Hammered Patron - Drink Dark Iron Ale');
 
 
-UPDATE `creature_template` SET `ScriptName`='npc_oozeling_jubjub' WHERE entry in  (14867,15429,14878);
-UPDATE `creature_template` SET `gossip_menu_id`=14871, `npcflag`=1, `ScriptName`='npc_morja' WHERE `entry`=14871;
-
+-- Morja
+UPDATE `creature_template` SET `gossip_menu_id`=14871, `npcflag`=1, `AIName`='EventAI', `ScriptName`='' WHERE `entry`=14871;
 REPLACE INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (14871, 31, 147, 2);
 REPLACE INTO `gossip_menu` VALUES (14871, 7400, 0),(14871, 7401, 14871);
 REPLACE INTO `npc_text` (`ID`, `BroadcastTextID0`, `Probability0`) VALUES (7401, 10169, 1);
+REPLACE INTO `spell_script_target` (`entry`, `type`, `targetEntry`) VALUES (23845, 1, 14867);
+UPDATE `quest_template` SET `RewSpellCast`=23852 WHERE `entry`=7946;
+
+REPLACE INTO `creature_ai_scripts` VALUES 
+(955405, 14871, 0, 8, 0, 100, 1, 14813, -1, 120000, 120000, 50, 10002, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Start event on Dark Iron Ale hit');
+
+DELETE FROM `event_scripts` WHERE `id`=10002;
+INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `buddy_id`, `buddy_radius`, `buddy_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES 
+(10002, 15, 15, 23845, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Attract Jubjub');
+
+
+-- Jubjub
+UPDATE `creature_template` SET `AIName`='EventAI', `ScriptName`='' WHERE entry in (14867);
 UPDATE `creature` SET `modelid`=0, `spawntimesecsmin`=300, `spawntimesecsmax`=300 WHERE `guid`=54428;
 REPLACE INTO `creature` VALUES (54427, 14867, 0, 0, 0, -9549.04, 38.9258, 59.2559, 3.58223, 300, 300, 0, 0, 166, 0, 0, 0, 0, 0, 0, 10);
 REPLACE INTO `game_event_creature` (`guid`, `event`) VALUES (54427, 4);
-REPLACE INTO `spell_script_target` (`entry`, `type`, `targetEntry`) VALUES (23845, 1, 14867);
-UPDATE `quest_template` SET `RewSpellCast`=23852 WHERE `entry`=7946;
+
+REPLACE INTO `creature_ai_scripts` VALUES 
+(955406, 14867, 0, 29, 0, 100, 1, 8, 1, 120000, 120000, 50, 10003, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Start event when reaching Dark Iron ale');
+
+DELETE FROM `event_scripts` WHERE `id`=10003;
+INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `buddy_id`, `buddy_radius`, `buddy_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES 
+(10003, 0, 0, 0, 0, 0, 0, 14871, 10, 0, 1, 10170, 0, 0, 0, 0, 0, 0, 0, 'Morja - Jubjub found text'),
+(10003, 0, 4, 147, 2, 1, 0, 14871, 10, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Enable quest giver flag'),
+(10003, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 10167, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Guzzle Ale emote'),
+(10003, 3, 41, 0, 0, 0, 0, 165578, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Remove Mug'),
+(10003, 120, 4, 147, 2, 2, 0, 14871, 10, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Disable quest giver flag'),
+(10003, 120, 0, 0, 0, 0, 0, 14871, 10, 0, 1, 10171, 0, 0, 0, 0, 0, 0, 0, 'Morja - Jubjub gone text'),
+(10003, 120, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Despawn');
 
 
 -- End of migration.

--- a/sql/migrations/20180224160415_world.sql
+++ b/sql/migrations/20180224160415_world.sql
@@ -30,10 +30,8 @@ REPLACE INTO `creature_ai_scripts` VALUES
 UPDATE `creature_template` SET `ScriptName`='npc_oozeling_jubjub' WHERE entry in  (14867,15429,14878);
 UPDATE `creature_template` SET `gossip_menu_id`=14871, `npcflag`=1, `ScriptName`='npc_morja' WHERE `entry`=14871;
 
--- Jubjub in range condition?
--- REPLACE INTO `conditions` (`condition_entry`, `type`, `value1`) VALUES (14871, 0, 0);
-
-REPLACE INTO `gossip_menu` VALUES (14871, 7400, 0); -- ,(14871, 7401, 14871);
+REPLACE INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (14871, 31, 147, 2);
+REPLACE INTO `gossip_menu` VALUES (14871, 7400, 0),(14871, 7401, 14871);
 REPLACE INTO `npc_text` (`ID`, `BroadcastTextID0`, `Probability0`) VALUES (7401, 10169, 1);
 UPDATE `creature` SET `modelid`=0, `spawntimesecsmin`=300, `spawntimesecsmax`=300 WHERE `guid`=54428;
 REPLACE INTO `creature` VALUES (54427, 14867, 0, 0, 0, -9549.04, 38.9258, 59.2559, 3.58223, 300, 300, 0, 0, 166, 0, 0, 0, 0, 0, 0, 10);

--- a/sql/migrations/20180224160415_world.sql
+++ b/sql/migrations/20180224160415_world.sql
@@ -1,0 +1,50 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180224160415');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180224160415');
+-- Add your query below.
+
+
+REPLACE INTO `spell_effect_mod` VALUES (14814, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 8, -1, -1, -1, -1, -1, -1, 'Throw Dark Iron Ale targetting');
+REPLACE INTO `spell_effect_mod` VALUES (14823, 2, 3, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, 'Dark Iron Ale dummy effect');
+REPLACE INTO `spell_mod` VALUES (14823, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, -1, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, 'BRD Drinking: Not Passive');
+REPLACE INTO `spell_script_target` (`entry`, `type`, `targetEntry`) VALUES (14813, 1, 9547),(14813, 1, 9554),(14813, 1, 9545),(14813, 1, 15429),(14813, 1, 14867),(14813, 1, 14871),(14813, 1, 14878);
+UPDATE `gameobject_template` SET `displayId`=3151, `data2`=20, `data4`=0, `data5`=70000 WHERE `entry`=165578;
+
+DELETE FROM `event_scripts` WHERE `id`=10001;
+INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `buddy_id`, `buddy_radius`, `buddy_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES 
+(10001, 0, 1, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'BRD Bar Patron - Drink Emote'),
+(10001, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 10167, 0, 0, 0, 0, 0, 0, 0, 'BRD Bar Patron - Text Emote'),
+(10001, 3, 15, 14823, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'BRD Bar Patron - Cast Drinking');
+
+REPLACE INTO `creature_ai_scripts` VALUES 
+(954703, 9547, 0, 29, 0, 100, 1, 8, 1, 0, 0, 50, 10001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Guzzling Patron - Drink Dark Iron Ale'),
+(954502, 9545, 0, 29, 0, 100, 1, 8, 1, 0, 0, 50, 10001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Grim Patron - Drink Dark Iron Ale'),
+(955404, 9554, 0, 29, 0, 100, 1, 8, 1, 0, 0, 50, 10001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Hammered Patron - Drink Dark Iron Ale');
+
+
+UPDATE `creature_template` SET `ScriptName`='npc_oozeling_jubjub' WHERE entry in  (14867,15429,14878);
+UPDATE `creature_template` SET `gossip_menu_id`=14871, `npcflag`=1, `ScriptName`='npc_morja' WHERE `entry`=14871;
+
+-- Jubjub in range condition?
+-- REPLACE INTO `conditions` (`condition_entry`, `type`, `value1`) VALUES (14871, 0, 0);
+
+REPLACE INTO `gossip_menu` VALUES (14871, 7400, 0); -- ,(14871, 7401, 14871);
+REPLACE INTO `npc_text` (`ID`, `BroadcastTextID0`, `Probability0`) VALUES (7401, 10169, 1);
+UPDATE `creature` SET `modelid`=0, `spawntimesecsmin`=300, `spawntimesecsmax`=300 WHERE `guid`=54428;
+REPLACE INTO `creature` VALUES (54427, 14867, 0, 0, 0, -9549.04, 38.9258, 59.2559, 3.58223, 300, 300, 0, 0, 166, 0, 0, 0, 0, 0, 0, 10);
+REPLACE INTO `game_event_creature` (`guid`, `event`) VALUES (54427, 4);
+REPLACE INTO `spell_script_target` (`entry`, `type`, `targetEntry`) VALUES (23845, 1, 14867);
+UPDATE `quest_template` SET `RewSpellCast`=23852 WHERE `entry`=7946;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20180224160415_world.sql
+++ b/sql/migrations/20180224160415_world.sql
@@ -57,12 +57,12 @@ REPLACE INTO `creature_ai_scripts` VALUES
 
 DELETE FROM `event_scripts` WHERE `id`=10003;
 INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `buddy_id`, `buddy_radius`, `buddy_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES 
-(10003, 0, 0, 0, 0, 0, 0, 14871, 10, 0, 1, 10170, 0, 0, 0, 0, 0, 0, 0, 'Morja - Jubjub found text'),
-(10003, 0, 4, 147, 2, 1, 0, 14871, 10, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Enable quest giver flag'),
+(10003, 0, 0, 0, 0, 0, 0, 14871, 50, 0, 1, 10170, 0, 0, 0, 0, 0, 0, 0, 'Morja - Jubjub found text'),
+(10003, 0, 4, 147, 2, 1, 0, 14871, 50, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Enable quest giver flag'),
 (10003, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 10167, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Guzzle Ale emote'),
 (10003, 3, 41, 0, 0, 0, 0, 165578, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Remove Mug'),
-(10003, 120, 4, 147, 2, 2, 0, 14871, 10, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Disable quest giver flag'),
-(10003, 120, 0, 0, 0, 0, 0, 14871, 10, 0, 1, 10171, 0, 0, 0, 0, 0, 0, 0, 'Morja - Jubjub gone text'),
+(10003, 119, 0, 0, 0, 0, 0, 14871, 50, 0, 1, 10171, 0, 0, 0, 0, 0, 0, 0, 'Morja - Jubjub gone text'),
+(10003, 120, 4, 147, 2, 2, 0, 14871, 50, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Morja - Disable quest giver flag'),
 (10003, 120, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jubjub - Despawn');
 
 

--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -357,6 +357,12 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& pHolder, Unit* pAction
             pHolder.UpdateRepeatTimer(m_creature, event.buffed.repeatMin, event.buffed.repeatMax);
             break;
         }
+        case EVENT_T_MOVEMENT_INFORM:
+        {
+            //Repeat Timers
+            pHolder.UpdateRepeatTimer(m_creature, event.move_inform.repeatMin, event.move_inform.repeatMax);
+            break;
+        }
         default:
             sLog.outErrorDb("CreatureEventAI: Creature %u using Event %u has invalid Event Type(%u), missing from ProcessEvent() Switch.", m_creature->GetEntry(), pHolder.Event.event_id, pHolder.Event.event_type);
             break;
@@ -1173,6 +1179,17 @@ void CreatureEventAI::SpellHit(Unit* pUnit, const SpellEntry* pSpell)
             if (!(*i).Event.spell_hit.spellId || pSpell->Id == (*i).Event.spell_hit.spellId)
                 if (GetSchoolMask(pSpell->School) & (*i).Event.spell_hit.schoolMask)
                     ProcessEvent(*i, pUnit);
+}
+
+void CreatureEventAI::MovementInform(uint32 type, uint32 id)
+{
+    if (m_bEmptyList)
+        return;
+
+    for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
+        if ((*i).Event.event_type == EVENT_T_MOVEMENT_INFORM)
+            if ((*i).Event.move_inform.motionType == type && (*i).Event.move_inform.pointId == id)
+                ProcessEvent(*i);
 }
 
 void CreatureEventAI::UpdateAI(const uint32 diff)

--- a/src/game/AI/CreatureEventAI.h
+++ b/src/game/AI/CreatureEventAI.h
@@ -66,6 +66,7 @@ enum EventAI_Type
     EVENT_T_SUMMONED_JUST_DESPAWN   = 26,                   // CreatureId, RepeatMin, RepeatMax
     EVENT_T_MISSING_AURA            = 27,                   // Param1 = SpellID, Param2 = Number of time stacked expected, Param3/4 Repeat Min/Max
     EVENT_T_TARGET_MISSING_AURA     = 28,                   // Param1 = SpellID, Param2 = Number of time stacked expected, Param3/4 Repeat Min/Max
+    EVENT_T_MOVEMENT_INFORM         = 29,                   // Param1 = motion type, Param2 = point ID, RepeatMin, RepeatMax
 
     EVENT_T_END,
 };
@@ -540,6 +541,14 @@ struct CreatureEventAI_Event
             uint32 repeatMin;
             uint32 repeatMax;
         } buffed;
+        // EVENT_T_MOVEMENT_INFORM                          = 29
+        struct
+        {
+            uint32 motionType;
+            uint32 pointId;
+            uint32 repeatMin;
+            uint32 repeatMax;
+        } move_inform;
         // RAW
         struct
         {
@@ -604,6 +613,7 @@ class MANGOS_DLL_SPEC CreatureEventAI : public CreatureAI
         void AttackStart(Unit *who) override;
         void MoveInLineOfSight(Unit *who) override;
         void SpellHit(Unit* pUnit, const SpellEntry* pSpell) override;
+        void MovementInform(uint32 type, uint32 id) override;
         void DamageTaken(Unit* done_by, uint32& damage) override;
         void UpdateAI(const uint32 diff) override;
         void ReceiveEmote(Player* pPlayer, uint32 text_emote) override;

--- a/src/game/AI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/CreatureEventAIMgr.cpp
@@ -371,6 +371,14 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                         sLog.outErrorDb("CreatureEventAI:  Creature %u are using repeatable event(%u) with param4 < param3 (RepeatMax < RepeatMin). Event will never repeat.", temp.creature_id, i);
                     break;
                 }
+                case EVENT_T_MOVEMENT_INFORM:
+                {
+                    if (temp.move_inform.motionType > CHARGE_MOTION_TYPE)
+                        sLog.outErrorDb("CreatureEventAI:  Creature %u is using an invalid motion type. Event %u will never trigger! ", temp.creature_id, i);
+                    if (temp.move_inform.repeatMax < temp.move_inform.repeatMin)
+                        sLog.outErrorDb("CreatureEventAI:  Creature %u are using repeatable event(%u) with param4 < param3 (RepeatMax < RepeatMin). Event will never repeat.", temp.creature_id, i);
+                    break;
+                }
                 default:
                     sLog.outErrorDb("CreatureEventAI: Creature %u using not checked at load event (%u) in event %u. Need check code update?", temp.creature_id, temp.event_id, i);
                     break;

--- a/src/game/Maps/Map.h
+++ b/src/game/Maps/Map.h
@@ -684,6 +684,7 @@ class MANGOS_DLL_SPEC Map : public GridRefManager<NGridType>, public MaNGOS::Obj
         bool ScriptCommand_SetData64(ScriptAction& step, Object* source, Object* target);
         bool ScriptCommand_StartScript(ScriptAction& step, Object* source, Object* target);
         bool ScriptCommand_RemoveItem(ScriptAction& step, Object* source, Object* target);
+        bool ScriptCommand_RemoveGameObject(ScriptAction& step, Object* source, Object* target);
 
         // Add any new script command functions to the array.
         const ScriptCommandFunction m_ScriptCommands[SCRIPT_COMMAND_MAX] =
@@ -729,6 +730,7 @@ class MANGOS_DLL_SPEC Map : public GridRefManager<NGridType>, public MaNGOS::Obj
             &Map::ScriptCommand_SetData64,              // 38
             &Map::ScriptCommand_StartScript,            // 39
             &Map::ScriptCommand_RemoveItem,             // 40
+            &Map::ScriptCommand_RemoveGameObject,       // 41
         };
 
     public:

--- a/src/game/Maps/ScriptCommands.cpp
+++ b/src/game/Maps/ScriptCommands.cpp
@@ -1197,3 +1197,26 @@ bool Map::ScriptCommand_RemoveItem(ScriptAction& step, Object* source, Object* t
 
     return false;
 }
+
+// SCRIPT_COMMAND_REMOVE_OBJECT (41)
+bool Map::ScriptCommand_RemoveGameObject(ScriptAction& step, Object* source, Object* target)
+{
+    Unit* pUser = nullptr;
+    GameObject *pGo = nullptr;
+
+    if (!((pUser = ToUnit(source)) || (pUser = ToUnit(target))))
+    {
+        sLog.outError("SCRIPT_COMMAND_REMOVE_OBJECT (script id %u) call for a NULL user, skipping.", step.script->id);
+        return ShouldAbortScript(step);
+    }
+
+    if (!((pGo = ToGameObject(target)) || (pGo = ToGameObject(source))))
+    {
+        sLog.outError("SCRIPT_COMMAND_REMOVE_OBJECT (script id %u) call for a NULL gameobject, skipping.", step.script->id);
+        return ShouldAbortScript(step);
+    }
+
+    pGo->SetLootState(GO_JUST_DEACTIVATED);
+    pGo->AddObjectToRemoveList();
+    return false;
+}

--- a/src/game/Maps/ScriptCommands.cpp
+++ b/src/game/Maps/ScriptCommands.cpp
@@ -1201,14 +1201,7 @@ bool Map::ScriptCommand_RemoveItem(ScriptAction& step, Object* source, Object* t
 // SCRIPT_COMMAND_REMOVE_OBJECT (41)
 bool Map::ScriptCommand_RemoveGameObject(ScriptAction& step, Object* source, Object* target)
 {
-    Unit* pUser = nullptr;
     GameObject *pGo = nullptr;
-
-    if (!((pUser = ToUnit(source)) || (pUser = ToUnit(target))))
-    {
-        sLog.outError("SCRIPT_COMMAND_REMOVE_OBJECT (script id %u) call for a NULL user, skipping.", step.script->id);
-        return ShouldAbortScript(step);
-    }
 
     if (!((pGo = ToGameObject(target)) || (pGo = ToGameObject(source))))
     {

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -196,6 +196,8 @@ enum eScriptCommand
     SCRIPT_COMMAND_REMOVE_ITEM              = 40,           // source = Player (from provided source or target)
                                                             // datalong = item_entry
                                                             // datalong2 = amount
+    SCRIPT_COMMAND_REMOVE_OBJECT            = 41,           // source = GameObject
+                                                            // target = Unit
     SCRIPT_COMMAND_MAX,
 
     SCRIPT_COMMAND_DISABLED                 = 9999          // Script action was disabled during loading.
@@ -585,6 +587,8 @@ struct ScriptInfo
             uint32 itemEntry;                               // datalong
             uint32 amount;                                  // datalong2
         } removeItem;
+
+                                                            // SCRIPT_COMMAND_REMOVE_OBJECT (41)
 
         struct
         {

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -2304,7 +2304,7 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
         {
             if (m_spellInfo->Effect[effIndex] == SPELL_EFFECT_PERSISTENT_AREA_AURA)
                 break;
-            else if (m_spellInfo->Effect[effIndex] == SPELL_EFFECT_SUMMON)
+            else if (m_spellInfo->Effect[effIndex] == SPELL_EFFECT_SUMMON || m_spellInfo->Effect[effIndex] == SPELL_EFFECT_SUMMON_OBJECT_WILD)
             {
                 targetUnitMap.push_back(m_caster);
                 break;

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1509,15 +1509,6 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     }
                     return;
                 }
-                case 14823: // Dark Iron Ale despawn mug
-                {
-                    if (GameObject* pMug = unitTarget->FindNearestGameObject(165578, 1.0f))
-                    {
-                        pMug->SetLootState(GO_JUST_DEACTIVATED);
-                        pMug->AddObjectToRemoveList();
-                    }
-                    return;
-                }
                 case 23845: // Attract Jubjub
                 {
                     if (GameObject* pMug = m_caster->FindNearestGameObject(165578, 3.0f))

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1492,6 +1492,49 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     }
                     return;
                 }
+                case 14813: // Dark Iron Drunk Mug
+                {
+                    if (unitTarget->HasAura(14823) || unitTarget->GetEntry() == 14871)
+                        return;
+
+                    if (m_originalCasterGUID && m_originalCasterGUID.IsGameObject())
+                    {
+                        if (GameObject* pMug = unitTarget->GetMap()->GetGameObject(m_originalCasterGUID))
+                        {
+                            float fX, fY, fZ;
+                            pMug->GetContactPoint(unitTarget, fX, fY, fZ);
+                            unitTarget->GetMotionMaster()->MovePoint(1, fX, fY, fZ, MOVE_WALK_MODE);
+                            m_caster->SummonGameObject(165738, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 30000);
+                        }
+                    }
+                    return;
+                }
+                case 14823: // Dark Iron Ale despawn mug
+                {
+                    if (GameObject* pMug = unitTarget->FindNearestGameObject(165578, 1.0f))
+                    {
+                        pMug->SetLootState(GO_JUST_DEACTIVATED);
+                        pMug->AddObjectToRemoveList();
+                    }
+                    return;
+                }
+                case 23845: // Attract Jubjub
+                {
+                    if (GameObject* pMug = m_caster->FindNearestGameObject(165578, 3.0f))
+                    {
+                        float fX, fY, fZ;
+                        pMug->GetContactPoint(unitTarget, fX, fY, fZ);
+                        unitTarget->GetMotionMaster()->MovePoint(1, fX, fY, fZ, MOVE_WALK_MODE);
+                    }
+                    return;
+                }
+                case 23852: // Jubling Cooldown
+                {
+                    // Trigger 7 day cooldown
+                    SpellEntry const *spellInfo = sSpellMgr.GetSpellEntry(23851);
+                    unitTarget->AddSpellAndCategoryCooldowns(spellInfo, 19462);
+                    return;
+                }
             }
 
             //All IconID Check in there

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -3613,6 +3613,174 @@ bool QuestRewarded_npc_kwee_peddlefeet(Player* pPlayer, Creature* pCreature, con
     return true;
 }
 
+enum
+{
+    NPC_JUBJUB = 14867,
+    OBJECT_DARK_IRON_MUG = 165578,
+
+    SPELL_ATTRACT_JUBJUB = 23845,
+    SPELL_DARK_IRON_MUG = 14813,
+
+    TEXT_GONE_JUBJUB = 10171,
+    TEXT_FOUND_JUBJUB = 10170,
+    EMOTE_GUZZLE_ALE = 10167,
+
+    JUBJUB_MIN_TIME = 10000,
+    JUBJUB_MAX_TIME = 30000,
+    MORJA_EVENT_DURATION = 60000
+};
+
+struct npc_morjaAI : public ScriptedAI
+{
+    npc_morjaAI(Creature* pCreature) : ScriptedAI(pCreature), uiEventCount(0), uiEventTimer(0)
+    {
+        Reset();
+    }
+
+    uint32 uiEventCount;
+    uint32 uiEventTimer;
+    void Reset() { }
+
+    void SpellHit(Unit* pUnit, const SpellEntry* pSpell)
+    {
+        if (!uiEventCount && pSpell->Id == SPELL_DARK_IRON_MUG)
+        {
+            if (GameObject* pMug = m_creature->FindNearestGameObject(OBJECT_DARK_IRON_MUG, 3.0f))
+            {
+                uiEventCount = 1;
+                uiEventTimer = urand(JUBJUB_MIN_TIME, JUBJUB_MAX_TIME);
+            }
+        }
+    }
+
+    void MoveInLineOfSight(Unit* pWho) override
+    {
+        if (!pWho)
+            return;
+
+        if (uiEventCount == 2 && m_creature->GetDistance(pWho) < 3.0f && pWho->GetEntry() == NPC_JUBJUB)
+        {
+            m_creature->MonsterSay(TEXT_FOUND_JUBJUB);
+            m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
+            uiEventTimer = MORJA_EVENT_DURATION;
+            uiEventCount = 3;
+        }
+    }
+
+    void UpdateAI(const uint32 uiDiff)
+    {
+        switch (uiEventCount)
+        {
+        case 1:
+            if (uiEventTimer < uiDiff)
+            {
+                if (Creature* pJubjub = m_creature->FindNearestCreature(NPC_JUBJUB, 50.0f))
+                {
+                    m_creature->CastSpell(m_creature, SPELL_ATTRACT_JUBJUB, true);
+                    uiEventTimer = 20000;
+                    uiEventCount = 2;
+                }
+                else
+                {
+                    uiEventCount = 0;
+                    uiEventTimer = 0;
+                }
+            }
+            else
+                uiEventTimer -= uiDiff;
+            break;
+        case 2:
+            if (uiEventTimer < uiDiff)
+            {
+                uiEventCount = 0;
+                uiEventTimer = 0;
+            }
+            else
+                uiEventTimer -= uiDiff;
+            break;
+        case 3:
+            if (uiEventTimer < uiDiff)
+            {
+                uiEventCount = 0;
+                uiEventTimer = 0;
+                if (Creature* pJubjub = m_creature->FindNearestCreature(NPC_JUBJUB, 4.0f))
+                {
+                    m_creature->MonsterSay(TEXT_GONE_JUBJUB);
+                    m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
+                    pJubjub->DespawnOrUnsummon();
+                }
+            }
+            else
+                uiEventTimer -= uiDiff;
+            break;
+        }
+    }
+};
+
+CreatureAI* GetAI_npc_morja(Creature* pCreature)
+{
+    return new npc_morjaAI(pCreature);
+}
+
+struct npc_oozeling_jubjubAI : public ScriptedPetAI
+{
+    npc_oozeling_jubjubAI(Creature* pCreature) : ScriptedPetAI(pCreature)
+    {
+        Reset();
+    }
+
+    uint32 m_uiReturnTimer;
+    void Reset()
+    {
+        m_uiReturnTimer = 0;
+    }
+
+    void SpellHit(Unit* pUnit, const SpellEntry* pSpell)
+    {
+        if (pSpell->Id == SPELL_DARK_IRON_MUG)
+            m_uiReturnTimer = 10000;
+    }
+
+    void MovementInform(uint32 type, uint32 id)
+    {
+        if (type == POINT_MOTION_TYPE && id == 1)
+        {
+            m_creature->MonsterTextEmote(EMOTE_GUZZLE_ALE);
+            m_creature->addUnitState(UNIT_STAT_ROOT);
+            m_uiReturnTimer = 3000;
+        }
+    }
+
+    void UpdateAI(const uint32 uiDiff)
+    {
+        if (m_uiReturnTimer > 0)
+        {
+            if (m_uiReturnTimer <= uiDiff)
+            {
+                m_uiReturnTimer = 0;
+                m_creature->clearUnitState(UNIT_STAT_ROOT);
+
+                if (GameObject* pMug = m_creature->FindNearestGameObject(OBJECT_DARK_IRON_MUG, 1.0f))
+                {
+                    pMug->SetLootState(GO_JUST_DEACTIVATED);
+                    pMug->AddObjectToRemoveList();
+                }
+            }
+            else
+                m_uiReturnTimer -= uiDiff;
+        }
+        else
+        {
+            ScriptedPetAI::UpdateAI(uiDiff);
+        }
+    }
+};
+
+CreatureAI* GetAI_npc_oozeling_jubjub(Creature* pCreature)
+{
+    return new npc_oozeling_jubjubAI(pCreature);
+}
+
 void AddSC_npcs_special()
 {
     Script *newscript;
@@ -3790,5 +3958,15 @@ void AddSC_npcs_special()
     newscript->GetAI = &GetAI_npc_kwee_peddlefeet;
     newscript->pGossipHello = &GossipHello_npc_kwee_peddlefeet;
     newscript->pQuestRewardedNPC = &QuestRewarded_npc_kwee_peddlefeet;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "npc_oozeling_jubjub";
+    newscript->GetAI = &GetAI_npc_oozeling_jubjub;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "npc_morja";
+    newscript->GetAI = &GetAI_npc_morja;
     newscript->RegisterSelf();
 }

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -3615,112 +3615,10 @@ bool QuestRewarded_npc_kwee_peddlefeet(Player* pPlayer, Creature* pCreature, con
 
 enum
 {
-    NPC_JUBJUB = 14867,
     OBJECT_DARK_IRON_MUG = 165578,
-
-    SPELL_ATTRACT_JUBJUB = 23845,
     SPELL_DARK_IRON_MUG = 14813,
-
-    TEXT_GONE_JUBJUB = 10171,
-    TEXT_FOUND_JUBJUB = 10170,
     EMOTE_GUZZLE_ALE = 10167,
-
-    JUBJUB_MIN_TIME = 10000,
-    JUBJUB_MAX_TIME = 30000,
-    MORJA_EVENT_DURATION = 60000
 };
-
-struct npc_morjaAI : public ScriptedAI
-{
-    npc_morjaAI(Creature* pCreature) : ScriptedAI(pCreature), uiEventCount(0), uiEventTimer(0)
-    {
-        Reset();
-    }
-
-    uint32 uiEventCount;
-    uint32 uiEventTimer;
-    void Reset() { }
-
-    void SpellHit(Unit* pUnit, const SpellEntry* pSpell)
-    {
-        if (!uiEventCount && pSpell->Id == SPELL_DARK_IRON_MUG)
-        {
-            if (GameObject* pMug = m_creature->FindNearestGameObject(OBJECT_DARK_IRON_MUG, 3.0f))
-            {
-                uiEventCount = 1;
-                uiEventTimer = urand(JUBJUB_MIN_TIME, JUBJUB_MAX_TIME);
-            }
-        }
-    }
-
-    void MoveInLineOfSight(Unit* pWho) override
-    {
-        if (!pWho)
-            return;
-
-        if (uiEventCount == 2 && m_creature->GetDistance(pWho) < 3.0f && pWho->GetEntry() == NPC_JUBJUB)
-        {
-            m_creature->MonsterSay(TEXT_FOUND_JUBJUB);
-            m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
-            uiEventTimer = MORJA_EVENT_DURATION;
-            uiEventCount = 3;
-        }
-    }
-
-    void UpdateAI(const uint32 uiDiff)
-    {
-        switch (uiEventCount)
-        {
-        case 1:
-            if (uiEventTimer < uiDiff)
-            {
-                if (Creature* pJubjub = m_creature->FindNearestCreature(NPC_JUBJUB, 50.0f))
-                {
-                    m_creature->CastSpell(m_creature, SPELL_ATTRACT_JUBJUB, true);
-                    uiEventTimer = 20000;
-                    uiEventCount = 2;
-                }
-                else
-                {
-                    uiEventCount = 0;
-                    uiEventTimer = 0;
-                }
-            }
-            else
-                uiEventTimer -= uiDiff;
-            break;
-        case 2:
-            if (uiEventTimer < uiDiff)
-            {
-                uiEventCount = 0;
-                uiEventTimer = 0;
-            }
-            else
-                uiEventTimer -= uiDiff;
-            break;
-        case 3:
-            if (uiEventTimer < uiDiff)
-            {
-                uiEventCount = 0;
-                uiEventTimer = 0;
-                if (Creature* pJubjub = m_creature->FindNearestCreature(NPC_JUBJUB, 4.0f))
-                {
-                    m_creature->MonsterSay(TEXT_GONE_JUBJUB);
-                    m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
-                    pJubjub->DespawnOrUnsummon();
-                }
-            }
-            else
-                uiEventTimer -= uiDiff;
-            break;
-        }
-    }
-};
-
-CreatureAI* GetAI_npc_morja(Creature* pCreature)
-{
-    return new npc_morjaAI(pCreature);
-}
 
 struct npc_oozeling_jubjubAI : public ScriptedPetAI
 {
@@ -3963,10 +3861,5 @@ void AddSC_npcs_special()
     newscript = new Script;
     newscript->Name = "npc_oozeling_jubjub";
     newscript->GetAI = &GetAI_npc_oozeling_jubjub;
-    newscript->RegisterSelf();
-
-    newscript = new Script;
-    newscript->Name = "npc_morja";
-    newscript->GetAI = &GetAI_npc_morja;
     newscript->RegisterSelf();
 }


### PR DESCRIPTION
Issue: https://github.com/LightsHope/issues/issues/5

Added an EVENT_T_MOVEMENT_INFORM event to prevent having to hardcode the Patrons.
Most of it is done but need help with a couple of things:

- Need a condition to change Morja's gossip when the event is active, is there a way make an NPC_FLAG condition? Or a nearby NPC condition?

- The hardcoded pets could be moved to the DB, all we need is a command to remove a nearby object. Is this possible with the buddy system somehow?

