### PR TITLE
Map switch related fixes

### DIFF
--- a/src/game/Maps/MapManager.cpp
+++ b/src/game/Maps/MapManager.cpp
@@ -621,17 +621,17 @@ BattleGroundMap* MapManager::CreateBattleGroundMap(uint32 id, uint32 InstanceId,
 
 bool IsNorthTo(float x, float y, float const* limits, int count /* last case is limits[2*count - 1] */)
 {
-    int insideCount = 0;
+    bool isNorth = false;
     for (int i = 0; i < count - 1; ++i)
     {
         if ((limits[2*i + 1] < y && y < limits[2*i + 3]) || (limits[2*i + 1] > y && y > limits[2*i + 3]))
         {
             float threshold = limits[2*i] + (limits[2*i + 2] - limits[2*i]) * (y - limits[2*i + 1]) / (limits[2*i + 3] - limits[2*i + 1]);
             if (x > threshold)
-                ++insideCount;
+                isNorth = !isNorth;
         }
     }
-    return insideCount % 2 == 1;
+    return isNorth;
 }
 
 uint32 MapManager::GetContinentInstanceId(uint32 mapId, float x, float y, bool* transitionArea)
@@ -775,8 +775,8 @@ uint32 MapManager::GetContinentInstanceId(uint32 mapId, float x, float y, bool* 
                     1184.00f, -3915.00f,
                      737.00f, -3782.00f,
                      -75.00f, -3742.00f,
-                    -263.00f, -3836.00f,
-                    -173.00f, -4064.00f,
+                    -288.30f, -3863.80f, // Northwest path for shaman quest "Call of Fire"
+                    -282.30f, -4050.90f,
                      -81.00f, -4091.00f,
                      -49.00f, -4089.00f,
                      -16.00f, -4187.00f,
@@ -807,9 +807,10 @@ uint32 MapManager::GetContinentInstanceId(uint32 mapId, float x, float y, bool* 
                     -3472.819580f,   182.522476f, // Feralas
                     -4365.006836f, -1602.575439f, // the Barrens
                     -4515.219727f, -1681.356079f,
-                    -4543.093750f, -1882.869385f, // Thousand Needles
-                        -4824.16f,     -2310.11f,
-                    -5102.913574f, -2647.062744f,
+                    -4703.36035f , -2166.91016f, // Thousand Needles
+                    -4849.61377  , -2176.16284,  // Razorfen Downs outsides
+                    -4863.11377f , -2185.06274f,
+                    -5043.4502f  , -2431.94971f,
                     -5248.286621f, -3034.536377f,
                     -5246.920898f, -3339.139893f,
                     -5459.449707f, -4920.155273f, // Tanaris
@@ -951,6 +952,7 @@ void MapManager::ScheduleInstanceSwitch(Player* player, uint16 newInstance)
     ASSERT(mapId < LAST_CONTINENT_ID);
     m_scheduledInstanceSwitches_lock[mapId].acquire();
     m_scheduledInstanceSwitches[mapId][player] = newInstance;
+    player->SetPendingInstanceSwitch(true);
     m_scheduledInstanceSwitches_lock[mapId].release();
 }
 
@@ -964,6 +966,7 @@ void MapManager::SwitchPlayersInstances()
             Player* player = it->first;
             if (player->IsInWorld() && player->GetMapId() == continent)
                 player->SwitchInstance(it->second);
+            player->SetPendingInstanceSwitch(false);
         }
         m_scheduledInstanceSwitches[continent].clear();
     }

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -3122,6 +3122,13 @@ void Creature::OnLeaveCombat()
     UpdateCombatState(false);
     UpdateCombatWithZoneState(false);
 
+    // a delayed spell event could set the creature in combat again
+    auto itEvent = m_Events.GetEvents().begin();
+    for (; itEvent != m_Events.GetEvents().end(); ++itEvent)
+        if (SpellEvent* event = dynamic_cast<SpellEvent*>(itEvent->second))
+            if (event->GetSpell()->getState() != SPELL_STATE_FINISHED)
+                event->GetSpell()->cancel();
+
     if (_creatureGroup)
         _creatureGroup->OnLeaveCombat(this);
 

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -409,7 +409,8 @@ UpdateMask Player::updateVisualBits;
 Player::Player(WorldSession *session) : Unit(),
     m_mover(this), m_camera(this), m_reputationMgr(this),
     m_enableInstanceSwitch(true), m_currentTicketCounter(0),
-    m_honorMgr(this), m_bNextRelocationsIgnored(0)
+    m_honorMgr(this), m_bNextRelocationsIgnored(0),
+    m_pendingInstanceSwitch(false)
 {
     m_objectType |= TYPEMASK_PLAYER;
     m_objectTypeId = TYPEID_PLAYER;
@@ -1148,6 +1149,37 @@ void Player::SetDrunkValue(uint16 newDrunkenValue, uint32 itemId)
         m_detectInvisibilityMask &= ~(1 << 6);
 }
 
+// Used to update attacker creatures (including pets' attackers) combat status when a player switches map
+struct UpdateAttackersCombatHelper
+{
+    explicit UpdateAttackersCombatHelper(Player* _player) : player(_player) {}
+    void operator()(Unit* unit) const
+    {
+        for (Unit* attacker : unit->getAttackers())
+            if (attacker->IsCreature() && attacker->getVictim() == unit)
+            {
+                bool hasValidThreat = false;
+                ThreatList const& threatList = attacker->getThreatManager().getThreatList();
+                for (const auto threat : threatList)
+                    if (Unit* unit = threat->getTarget())
+                    {
+                        if (unit->GetCharmerOrOwnerPlayerOrPlayerItself() == player)
+                            continue;
+                        if (unit->IsInMap(attacker) &&
+                            (!unit->IsPlayer() ||
+                                !(unit->ToPlayer()->IsBeingTeleportedFar() || unit->ToPlayer()->IsPendingInstanceSwitch())))
+                        {
+                            hasValidThreat = true;
+                            break;
+                        }
+                    }
+                if (!hasValidThreat)
+                    attacker->ToCreature()->OnLeaveCombat();
+            }
+    }
+    Player* player;
+};
+
 void Player::Update(uint32 update_diff, uint32 p_time)
 {
     if (!IsInWorld())
@@ -1356,7 +1388,14 @@ void Player::Update(uint32 update_diff, uint32 p_time)
         uint16 newInstanceId = sMapMgr.GetContinentInstanceId(GetMap()->GetId(), GetPositionX(), GetPositionY(), &transition);
         if (newInstanceId != GetInstanceId())
             if (!transition || !isInCombat())
+            {
                 sMapMgr.ScheduleInstanceSwitch(this, newInstanceId);
+
+                // Update attacker creatures combat status if needed
+                UpdateAttackersCombatHelper helper(this);
+                helper(this);
+                CallForAllControlledUnits(helper, CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
+            }
     }
     if (IsInWorld())
     {
@@ -1967,6 +2006,11 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
         ScheduledTeleportData *data = new ScheduledTeleportData(mapid, x, y, z, orientation, options, recover);
 
         sMapMgr.ScheduleFarTeleport(this, data);
+
+        // Update attacker creatures combat status if needed
+        UpdateAttackersCombatHelper helper(this);
+        helper(this);
+        CallForAllControlledUnits(helper, CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
     }
     return true;
 }

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -1156,26 +1156,9 @@ struct UpdateAttackersCombatHelper
     void operator()(Unit* unit) const
     {
         for (Unit* attacker : unit->getAttackers())
-            if (attacker->IsCreature() && attacker->getVictim() == unit)
-            {
-                bool hasValidThreat = false;
-                ThreatList const& threatList = attacker->getThreatManager().getThreatList();
-                for (const auto threat : threatList)
-                    if (Unit* unit = threat->getTarget())
-                    {
-                        if (unit->GetCharmerOrOwnerPlayerOrPlayerItself() == player)
-                            continue;
-                        if (unit->IsInMap(attacker) &&
-                            (!unit->IsPlayer() ||
-                                !(unit->ToPlayer()->IsBeingTeleportedFar() || unit->ToPlayer()->IsPendingInstanceSwitch())))
-                        {
-                            hasValidThreat = true;
-                            break;
-                        }
-                    }
-                if (!hasValidThreat)
-                    attacker->ToCreature()->OnLeaveCombat();
-            }
+            if (Creature* creature = attacker->ToCreature())
+                if (attacker->getVictim() == unit)
+                    creature->SelectHostileTarget();
     }
     Player* player;
 };

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -2173,8 +2173,11 @@ class MANGOS_DLL_SPEC Player final: public Unit
 
         inline bool HasScheduledEvent() const { return m_Events.HasScheduledEvent(); }
         void SetAutoInstanceSwitch(bool v) { m_enableInstanceSwitch = v; }
+        void SetPendingInstanceSwitch(bool v) { m_pendingInstanceSwitch = v; }
+        bool IsPendingInstanceSwitch() const { return m_pendingInstanceSwitch; }
     protected:
         bool   m_enableInstanceSwitch;
+        bool   m_pendingInstanceSwitch;
         uint32 m_skippedUpdateTime;
         uint32 m_DetectInvTimer;
 

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1697,6 +1697,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
         bool IsBeingTeleported() const { return mSemaphoreTeleport_Near || mSemaphoreTeleport_Far || mPendingFarTeleport; }
         bool IsBeingTeleportedNear() const { return mSemaphoreTeleport_Near; }
         bool IsBeingTeleportedFar() const { return mSemaphoreTeleport_Far; }
+        bool IsPendingFarTeleport() const { return mPendingFarTeleport; }
         void SetSemaphoreTeleportNear(bool semphsetting);
         void SetSemaphoreTeleportFar(bool semphsetting);
         void SetPendingFarTeleport(bool pending) { mPendingFarTeleport = pending; }

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -7402,8 +7402,20 @@ bool Unit::isTargetableForAttack(bool inverseAlive /*=false*/) const
     if (!CanBeDetected())
         return false;
 
-    if (GetTypeId() == TYPEID_PLAYER && (((Player *)this)->isGameMaster() || ((Player*)this)->watching_cinematic_entry != 0))
-        return false;
+    if (const Player* player = GetCharmerOrOwnerPlayerOrPlayerItself())
+    {
+        if (player->isGameMaster())
+            return false;
+
+        // in such case, unlike a creature, a charmed Player can be targeted even if his charmer can't
+        if (const Player* charmedPlayer = ToPlayer())
+            player = charmedPlayer;
+
+        if (player->watching_cinematic_entry != 0 ||
+            player->IsPendingFarTeleport() ||
+            player->IsPendingInstanceSwitch())
+            return false;
+    }
 
     if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE))
         return false;


### PR DESCRIPTION
Move a bit instance lines on 2 places : 
- outside RFD the line was cutting through a pack of elite, now it separate non elite Thousand Needles side from RFD elites
- in the northwest corner of the Valley of Trials there's a place in the hills you can access from the north for a quest, the line was cutting through the way.

Implement something to deal with creatures attacking a player or his controlled on a map switch.
Currently a player can switch, regen out of combat and go back to the creature still in combat. It's also annoying and exploitable that creatures don't reset when entering/exiting a dungeon.
With this patch a creature that is attacking a player or controlled will reset if there's no other valid target in its threat list.

Also included a fix that prevent a creature to be put in combat again after reset by one of its previous spell cast. For example axes-thrower trolls in STV.
With this patch any spell that caused a SpellEvent in the creature event list is cancelled on reset.