### PR TITLE
Fix loading screens on transport when no map switch

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -1778,18 +1778,20 @@ bool Player::SwitchInstance(uint32 newInstanceId)
 
     Map* oldmap = GetMap();
 
-    // Leave transport
-    if (m_transport)
+    // Leave transport if absent from new instance
+    // normally it should have switched before the player
+    if (m_transport && m_transport->GetInstanceId() != newInstanceId)
     {
         m_transport->RemovePassenger(this);
         m_movementInfo.ClearTransportData();
+        m_movementInfo.RemoveMovementFlag(MOVEFLAG_ONTRANSPORT);
     }
     // Stop duel
     if (duel)
         if (GameObject* obj = GetMap()->GetGameObject(GetGuidValue(PLAYER_DUEL_ARBITER)))
             DuelComplete(DUEL_FLED);
     // Fix movement flags
-    m_movementInfo.RemoveMovementFlag(MOVEFLAG_MASK_MOVING_OR_TURN | MOVEFLAG_ONTRANSPORT);
+    m_movementInfo.RemoveMovementFlag(MOVEFLAG_MASK_MOVING_OR_TURN);
 
     SetSelectionGuid(ObjectGuid());
     CombatStop();


### PR DESCRIPTION
There's no need to force a player teleport after a transport teleportation without map change.
The client assumes the right position and is nice enough to show the correct loading screen for Undercity-Grom'gol. (that screen's direction seems impossible to be set properly on a server induced teleportation)
It also remove useless loading screens for Feathermoon-Savage Coast and Auberdine-Tel'drasil. And the 
weather change bug for Feathermoon-Savage Coast.